### PR TITLE
pintools/PinballSYSState: fix ReadState bug.

### DIFF
--- a/pintools/PinballSYSState/pinball-sysstate.H
+++ b/pintools/PinballSYSState/pinball-sysstate.H
@@ -417,7 +417,7 @@ class SYSSTATE_PRODUCER
       READ_STATE * rs = new READ_STATE(pc, buf_addr, req_count, act_count,
          filepos, fname);
       //rs->PrintReadState();
-      _read_state_list.push_front(rs);
+      _read_state_list.push_back(rs);
     }
 
     VOID AddCWDState(ADDRINT pc, ADDRINT buf_addr, INT32 buflength)


### PR DESCRIPTION
The `FindReadState` function walks from front to back. But the `AddReadState` function always inserts into the head of the list.

If read buffer intervals overlap, `FindReadState` looks up the first recorded READ_STATE, not the last. This keeps changing `_byte_accessed` in READ_STATE, which is recorded first. 

sde64 replay with `sde-pinball-sysstate.so` log:
```
Will produce sysstate in namd.test_3566277_t0r2_warmup1500_prolog0_region30000000_epilog0_002_0-04718.0.sysstate
Producer namd.test_3566277_t0r2_warmup1500_prolog0_region30000000_epilog0_002_0-04718.0
 Producer:SysAfter SYS_read threadid 0 num 0 ip 0x7f394cb271f0 retval 0x1000 fd 0x3 buf 0x16b5420 translated buf 0x16b5420 count 0x1000
Adding ReadState to  new FD 3 CWD/FD_3
 Producer:SysAfter SYS_read inserting CWD/FD_3
 Producer:SysAfter SYS_read threadid 0 num 0 ip 0x7f394cb271f0 retval 0x1000 fd 0x3 buf 0x16b5420 translated buf 0x16b5420 count 0x1000
Adding ReadState to  existing FD 3 CWD/FD_3
 Producer:SysAfter SYS_read threadid 0 num 0 ip 0x7f394cb271f0 retval 0x1000 fd 0x3 buf 0x16b5420 translated buf 0x16b5420 count 0x1000
```

Before solution, only the first 4K has data, and the rest are 0.
```shell
$ hexdump FD_3
0000f70 362e 3834 3030 2030 2e30 3134 3037 3030
0000f80 3320 3534 3735 3020 3020 3020 3020 3020
0000f90 2d0a 3032 352e 3338 3030 2030 342d 2e30
0000fa0 3433 3030 3030 2d20 3831 352e 3837 3030
0000fb0 2030 302d 382e 3433 3030 2030 3433 3535
0000fc0 2038 2033 2030 2030 2030 0a30 322d 2e30
0000fd0 3335 3034 3030 2d20 3933 332e 3136 3030
0000fe0 2030 312d 2e38 3036 3038 3030 3020 342e
0000ff0 3731 3030 2030 3433 3535 2039 2030 2030
0001000 0000 0000 0000 0000 0000 0000 0000 0000
*
002f000
$ ll -h FD_3
-rw-r--r-- 1 root root 188K Sep  6 18:05 FD_3
```

Before the problem is resolved, the perf slice execution error occurs, and no performance data is recorded
```
$ ./namd.test_3566277_t0r2_warmup1500_prolog0_region30000000_epilog0_002_0-04718.0.perf.elfie 
ELFIE_COREBASE=15
ELFIE_PERFLIST=0:0,0:1,1:1
Will set affinity using core_base: 15
  elfie tid: 0  core id: 15
------------------------------------------------
------------------------------------------------
WARNING: ELFie will open files with absolute pathname. Consider using chroot.
preopen_files():#must be in 'sysstate' to succeed 
atom read error
patch read error
error reading patchList from input file
free(): invalid pointer
Aborted

$ cat st.0.perf.txt 
ROI start: TSC 2445196930410700
Thread start: TSC 2445196994381660
------------------------------------------------
```

Attach function `FindReadState` and `AddReadState`

https://github.com/intel/pinball2elf/blob/master/pintools/PinballSYSState/pinball-sysstate.H#L435C1-L443C8
```
READ_STATE * FindReadState(ADDRINT memea, UINT32 bytes)
{
  READ_STATE * retval = NULL;
  READ_STATE_LIST :: iterator it;
  for ( it = _read_state_list.begin();
       it != _read_state_list.end(); ++it)
  {
    if((*it)->ReadAddrInRange(memea)
          && (*it)->ReadAddrInRange(memea+bytes-1))
    {
      retval = *it; 
    }
  }
  return retval;
}
```
https://github.com/intel/pinball2elf/blob/master/pintools/PinballSYSState/pinball-sysstate.H#L435C1-L443C8
```
VOID AddReadState(ADDRINT pc, ADDRINT buf_addr, INT32 req_count, INT32 act_count,
    INT32 filepos, string fname)
{
  if(act_count == 0) return; // read() returning zero is not interesting.
  READ_STATE * rs = new READ_STATE(pc, buf_addr, req_count, act_count,
     filepos, fname);
  //rs->PrintReadState();
  _read_state_list.push_front(rs);
}
```