### PR TITLE
instrumentation/perf_callbacks: fix my_out_fd bug.

### DIFF
--- a/instrumentation/perf_callbacks.c
+++ b/instrumentation/perf_callbacks.c
@@ -365,6 +365,10 @@ void elfie_on_start(uint64_t num_threads, void* context)
    lte_pe_init(num_threads, 0/*SIGPEOVFL*/, &set);
 
    uint64_t ptscstart = rdtsc();
+   
+   // preopen_files() definitions to be added by pinball2elf*.sh script
+   preopen_files(); 
+   
    int i;
    for(i = 0; i < lte_pe_get_num_threads(); ++i)
    {
@@ -377,8 +381,8 @@ void elfie_on_start(uint64_t num_threads, void* context)
         lte_diprintfe(my_out_fd, ptscstart, '\n');
       lte_fsync(my_out_fd);
    }
-  // preopen_files()  and set_heap() definitions to be added by pinball2elf*.sh script 
-   preopen_files();
+   
+   // set_heap() definitions to be added by pinball2elf*.sh script 
    set_heap();
 }
 


### PR DESCRIPTION
The execution of `lte_open` before `preopen_files()` may lead to a conflict between `my_out_fd` and the FD recorded in `sysstate`.

https://github.com/intel/pinball2elf/blob/c31c8a516522f450dc9872cb4dea1a0071ace9b0/instrumentation/perf_callbacks.c#L367C1-L382C15
```c
   uint64_t ptscstart = rdtsc();
   int i;
   for(i = 0; i < lte_pe_get_num_threads(); ++i)
   {
      if (i > FILECOUNT) continue;


      char* fname = my_output_file[i];
      out_fd[i] = lte_open(fname, O_WRONLY | O_CREAT | O_TRUNC , S_IRUSR|S_IWUSR|S_IRGRP);
      int my_out_fd = out_fd[i];
      lte_write(my_out_fd, "ROI start: TSC ", lte_strlen("ROI start: TSC ")-1); 
        lte_diprintfe(my_out_fd, ptscstart, '\n');
      lte_fsync(my_out_fd);
   }
  // preopen_files()  and set_heap() definitions to be added by pinball2elf*.sh script 
   preopen_files();
   set_heap();
```

The `sysstate` directory is as follows:
```shell
povray.test_3566250_t0r1_warmup1500_prolog0_region30000000_epilog0_001_0-01612.0.sysstate$ tree 
.
├── BRK.log
├── FD_3
├── FD_4
├── FD_5
├── FD_7
├── home
│   └── testcode
│       └── 511.povray_r
│           └── SPEC-benchmark.tga
├── povray.test_3566250_t0r1_warmup1500_prolog0_region30000000_epilog0_001_0-01612.0.perf.elfie
└── st.0.perf.txt
```

Before solution, the information in `st.0.perf.txt`：
```shell
$ cat st.0.perf.txt 
ROI start: TSC 1690369467426100
```

The information in `FD_4`：
```shell
$ head -n 5 FD_4 
Thread start: TSC 1690369565465640
------------------------------------------------
bulence <0.05, 0.08, 1>
    octaves 4
    scale <0.15, .15, 1>
```

We will find that the information which should have been recorded in `st.0.perf.txt` was printed in `FD_4` instead. After adding a print for `my_out_fd`, the value is indeed 4.

