### PR TITLE
pinball2elf/lib: fix libcle_c bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Addr  9decb1 tid: 3 addrcount 4368
 
 The  pages  inside an ELFie containing  application code  are  marked  as  not loadable hence  tools,  such  as  the Gnu  debugger  (gdb),  can  not  *see*  application  pages  inside an  ELFie  right  away  after  the  initial  loading  of  an  ELFie. For  setting  a breakpoint  at  an  application  instruction,  the suggested  way  is  to  first  break  at *elfie\_on\_start()* where all application pages are guaranteed to be in memory and then  set  a  breakpoint  at  the  desired  application  address(hex). Symbolic  debugging of application code is  currently  not  supported  with  ELFies although pinball2elf can be extended to add application debug information  for  symbolic  debugging. ELFie  generation  scripts  make  sure  debug  information  does exist for ELFie callback routines hence they can be debugged symbolically (use the customized callbacks.c file copied to the working directory).  For  debugging  multi-threaded  ELFies  with  gdb,  first  doing  a  *set  detach-on-fork off* followed by *break elfie\_on\_thread\_start’ and using *info inferior* and *inferior N* commands works well.
 
-A perf ELFie, creates a monitor thread which spawns application main thread and waits for it. For debugging a perf help, use 'set follow-fork-mode' child to break on 'elfie_thread_on_start' routine which is executed in the application master thread.
+A perf ELFie, creates a monitor thread which spawns application main thread and waits for it. For debugging a perf help, use 'set follow-fork-mode' child to break on 'elfie_on_thread_start' routine which is executed in the application master thread.
 
 ## Open issues
  ELFie execution sometimes ends pre-maturely (before reaching the expected instruction

--- a/src/lib/libcle_c.c
+++ b/src/lib/libcle_c.c
@@ -124,6 +124,9 @@ extern void lte_sys_exit(int status);
 
 void lte_exit(int status)
 {
+   if (!exit_callbacks_end) {
+      exit_callbacks_end = exit_callbacks;
+   }
    exit_callback_fn* callback = __sync_lock_test_and_set(&exit_callbacks_end, &exit_callbacks[0]);
    while(callback != &exit_callbacks[0])
       (*--callback)();


### PR DESCRIPTION
Due to unknown reasons, `exit_callbacks_end` is a null pointer before use, causing `callback` to also be a null pointer. When executing `(*--callback)();`, a `Segmentation fault` occurs. Therefore, additional checks are required, and an initial value needs to be reassigned.

https://github.com/intel/pinball2elf/blob/91f9982e506c437bba52b1d6c2cb1301ace24098/src/lib/libcle_c.c#L125C1-L131C2
```c
void lte_exit(int status)
{
   exit_callback_fn* callback = __sync_lock_test_and_set(&exit_callbacks_end, &exit_callbacks[0]);
   while(callback != &exit_callbacks[0])
      (*--callback)();
   lte_sys_exit(status);
}
```

Before solution, the output of executing the ELF file is:
```shell
$ ./povray.test_3566250_t0r1_warmup1500_prolog0_region30000000_epilog0_001_0-01612.0.perf.elfie 
ELFIE_COREBASE=10
ELFIE_PERFLIST=0:0,0:1,1:1
Will set affinity using core_base: 10
  elfie tid: 0  core id: 10
------------------------------------------------
------------------------------------------------
WARNING: ELFie will open files with absolute pathname. Consider using chroot.
ELFie will open local files. Must be in 'sysstate' to succeed.
preopen_files():#must be in 'sysstate' to succeed 
Segmentation fault
```

The information in `st.0.perf.txt`：
```
ROI start: TSC 3310053052267900
Thread start: TSC 3310053132973360
------------------------------------------------
Simulation end: TSC 3310053151804080
	Sim-end-icount 30001487
hw_cpu_cycles:18596213 hw_instructions:30002607 sw_task_clock:9280505 
------------------------------------------------
Thread end: TSC 3310053152117100
```