### PR TITLE
pintools/PinballSYSState: fix checkReadList bug.

### DIFF
--- a/pintools/PinballSYSState/pinball-sysstate.H
+++ b/pintools/PinballSYSState/pinball-sysstate.H
@@ -194,10 +194,10 @@ class READ_STATE
 {
  private:   
     ADDRINT _syscall_pc;
-    UINT32 _count_act;
  public:   
     UINT32 _file_pos;
     UINT32 _count_req;
+    UINT32 _count_act;
     string _fname;
     ADDRINT  _buf_addr;
     CHAR * _shadow_buf;
@@ -436,7 +436,7 @@ class SYSSTATE_PRODUCER
            it != _read_state_list.end(); ++it)
       {
         if((*it)->ReadAddrInRange(memea)
-              && (*it)->ReadAddrInRange(memea+bytes-1))
+              || (*it)->ReadAddrInRange(memea+bytes-1))
         {
           retval = *it; 
         }
@@ -496,7 +496,29 @@ class SYSSTATE_PRODUCER
             rs->PrintReadState();
             cerr << '\n' ;
 #endif
-            rs->SafeCopy((CHAR *)memea_callback, bytes);
+            if (rs->ReadAddrInRange(memea_callback) && rs->ReadAddrInRange(memea_callback + bytes - 1)) {
+                rs->SafeCopy((CHAR *)memea_callback, bytes);
+            } else if (rs->ReadAddrInRange(memea_callback)) {
+                rs->SafeCopy((CHAR *)memea_callback, rs->_buf_addr + rs->_count_act - memea_callback);
+
+                ADDRINT last_memea_callback = rs->_buf_addr + rs->_count_act;
+                UINT32 last_bytes = bytes - (last_memea_callback - memea_callback);
+
+                READ_STATE *lastrs = p->FindReadState(last_memea_callback, last_bytes);
+                if (lastrs) {
+                    lastrs->SafeCopy((CHAR *)last_memea_callback, last_bytes);
+                }
+            } else {
+                rs->SafeCopy((CHAR *)rs->_buf_addr, memea_callback + bytes - rs->_buf_addr);
+
+                ADDRINT last_memea_callback = memea_callback;
+                UINT32 last_bytes = bytes - (memea_callback + bytes - rs->_buf_addr);
+
+                READ_STATE *lastrs = p->FindReadState(last_memea_callback, last_bytes);
+                if (lastrs) {
+                    lastrs->SafeCopy((CHAR *)last_memea_callback, last_bytes);
+                }
+            }
             return;
         }
         rs = p->FindCWDState(memea_callback, bytes);


### PR DESCRIPTION
For the following situation, the `checkReadList` function might have incomplete checks.

The following is part of the output from `sde64 replay` with `sde-pinball-sysstate.so`, where the buffer address is `0x213d840`.

```
Producer:SysAfter SYS_read threadid 0 num 0 ip 0x7f83550781f0 retval 0x120c4 fd 0x3 buf 0x213d840 translated buf 0x213d840 count 0x120c4
```

During the process of generating the `sysstate` directory, I encountered the instruction `vmovdqu ymm1, ymmword ptr [rcx-0x20]`, where `rcx` is `0x213d848`. Correspondingly, the `checkReadList` function's parameter `memea_callback` is `0x213d828`, and `bytes` is `0x20`. According to the original definition in the `FindReadState` function, it cannot find a `READ_STATE` that meets the criteria.

https://github.com/intel/pinball2elf/blob/340c055aa4fa4b5b871916a0ea4f4cb1408268e1/pintools/PinballSYSState/pinball-sysstate.H#L431C1-L445C6
```hpp
    READ_STATE * FindReadState(ADDRINT memea, UINT32 bytes)
    {
      READ_STATE * retval = NULL;
      READ_STATE_LIST :: iterator it;
      for ( it = _read_state_list.begin();
           it != _read_state_list.end(); ++it)
      {
        if((*it)->ReadAddrInRange(memea)
              && (*it)->ReadAddrInRange(memea+bytes-1))
        {
          retval = *it; 
        }
      }
      return retval;
    }
```

However, in reality, `0x213d828 < 0x213d840 < 0x213d828 + 0x20`, so we still need to copy the last 8 bytes. Therefore, I adjusted the code to handle cases where only a portion of the memory region is present in the `READ_STATE`.