### PR TITLE
pinball2elf: fix region compact bug. 

### DIFF
--- a/src/lte_memimg.cpp
+++ b/src/lte_memimg.cpp
@@ -221,8 +221,12 @@ lte_uint64_t lte_memimg_t::compact(lte_uint64_t regions_max)
       for(std::vector<lte_mempage_t*>::iterator it = pages.begin(); it != pages.end(); ++it)
       {
          lte_mempage_t* p = *it;
-         if(same_type_pages(*p, *p->region_next, SHF_TYPE_MASK|SHF_ENTRYPOINT|SHF_DYNALLOC))
+         if(same_type_pages(*p, *p->region_next, SHF_EXECINSTR|SHF_ALLOC|SHF_ENTRYPOINT|SHF_DYNALLOC))
          {
+            if (p->region_next->va - p->va > 0x40000000)
+            {
+               continue;
+            }
             p->head = NULL;
             if(--regions_count < regions_max)
                break;


### PR DESCRIPTION
This PR primarily aims to address the issue of oversized ELF files during ELF region compaction.

I tested #18, and it successfully generated the `.perf.elfie` file. The content of the `st.0.perf.txt` file also meets expectations.

I have also encountered the issue of temporary ELF files in the `tmp` directory being too large. Due to the limitation on the number of ELF sections, it is necessary to merge regions. According to the logic in `lte_memimg_t::compact`, the process first fills several holes, followed by an initial merge of regions. After the first merge, if the number of regions still does not meet the requirements, they are further merged in ascending order of VA (determined using the `same_type_pages` function).

Since there is no restriction on the range of the two regions to be merged, cases may occur where the address difference between the two regions is too large. For example, merging 0x400800 and 0x7ffd43e58000. In #18, a similar case occurred where the regions with VA 0x14adf821c000 and 0x7ffd43e58000 were merged.

A more advanced algorithm could be used here for region merging. I temporarily relaxed the criteria for merging regions and added a restriction on the address difference between merged regions.