### PR TITLE
pintools/PinballSYSState: fix CWDName & SYS_brk bug.

### DIFF
--- a/pintools/PinballSYSState/pinball-sysstate.H
+++ b/pintools/PinballSYSState/pinball-sysstate.H
@@ -1926,9 +1926,14 @@ class SYSSTATE_CONSUMER
             cerr << "First SYS_brk: forced retval 0x" << hex << p->_first_brk_addr << endl;
           }
        }
+       else if(tdata->_data.arg0 == 0)
+       {
+          PIN_SetContextReg(ctxt, REG_GAX, p->_first_brk_addr);
+       }
        else if(tdata->_data.arg0 != 0)
        {
           PIN_SetContextReg(ctxt, REG_GAX, tdata->_data.arg0);
+          p->_first_brk_addr = tdata->_data.arg0;
           if(p->_verbose)
           {
             cerr << "SYS_brk: forced retval 0x" << hex << tdata->_data.arg0 << endl;

--- a/pintools/PinballSYSState/pinball-sysstate.H
+++ b/pintools/PinballSYSState/pinball-sysstate.H
@@ -1486,7 +1486,7 @@ class SYSSTATE_CONSUMER
         }
         else
         {
-          string cwdstring = mycwd + string("/") + _in_state_rootdirname + _cwd_path;
+          string cwdstring = mycwd + string("/") + _in_state_rootdirname + _cwd_path + string("/");
           return cwdstring;
         }
       }


### PR DESCRIPTION
When using the `-sysstate:in` parameter for replay, i.e., using the CONSUMER in **PinballSYSState**, the following issues are encountered:

1. **CWDName bug**.

When encountering `SYS_openat`, if the path being opened is not an absolute path, `p->CWDName()` is used to retrieve the current working directory. A `/` needs to be appended to the end of this path; otherwise, the following error may occur in practice. Below is the log recorded during an `sde64 replay` with `sde-pinball-sysstate.so`:
```
 Modified *buf /home/xx/intel/testcode/511.povray_r/slice/povray.test_3566250_t0r8_warmup0_prolog0_region30000001_epilog0_008_0-01612.0/povray.test_3566250_t0r8_warmup0_prolog0_region30000001_epilog0_008_0-01612.0.sysstate/home/xx/intel/testcode/511.povray_r
 Consumer:SysAfter SYS_openat threadid 0 num 0x101 ip 0x7f2baaa4ef59 retval 0xffffffffffffffff arg 1 0x718fd0 pathname SPEC-benchmark-test.pov
```

2. **SYS_brk bug**.

When encountering `SYS_brk`, it is necessary to additionally handle the case where the first parameter is `0`. If the first parameter is `0`, the current heap top address is returned. If the first parameter is not `0`, the current heap top address is recorded.